### PR TITLE
🧑‍💻 Remove static analysis feature from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,7 @@
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "./features/src/postgresql": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:0": {}
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:0": {}
   },
   "postCreateCommand": "bash scripts/devcontainer/post-create.sh",
   "postStartCommand": "bash scripts/devcontainer/post-start.sh",


### PR DESCRIPTION
This removes static analysis from the devcontainer. If included, this gives the error:
```bash
ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: 'LICENSE.txt'
Consider using the `--user` option or check the permissions.
```
